### PR TITLE
Lock to older known-working versions of node and yarn

### DIFF
--- a/app.json
+++ b/app.json
@@ -76,10 +76,10 @@
       "description": "If using Google Cloud to store visualization images posted by Lookerbot, provide the content of the credentials JSON file you got from the Google Cloud website.",
       "required": false
     },
-    "YARN_PRODUCTION": {
-      "description": "Set to false by default to skip npm dependency pruning, which may unintentionally omit the installation of some required packages. See https://devcenter.heroku.com/articles/nodejs-support#skip-pruning for more details.",
+    "YARN2_SKIP_PRUNING": {
+      "description": "Set to true by default to skip npm dependency pruning, which may unintentionally omit the installation of some required packages. See https://devcenter.heroku.com/articles/nodejs-support#skip-pruning for more details.",
       "required": false,
-      "value": "false"
+      "value": "true"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "engines": {
     "node": "18",
-    "yarn": "2"
+    "yarn": "1.19"
   },
   "resolutions": {
     "**/request": "https://github.com/request/request/archive/392db7d127536ff296fb06492db9430790a32d6c.tar.gz"

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "tslint": "^5.9.1"
   },
   "engines": {
-    "node": "= 12.13",
-    "yarn": "= 1.19"
+    "node": "18",
+    "yarn": "2"
   },
   "resolutions": {
     "**/request": "https://github.com/request/request/archive/392db7d127536ff296fb06492db9430790a32d6c.tar.gz"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "engines": {
     "node": "18",
-    "yarn": "1.19"
+    "yarn": "2"
   },
   "resolutions": {
     "**/request": "https://github.com/request/request/archive/392db7d127536ff296fb06492db9430790a32d6c.tar.gz"

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "tslint": "^5.9.1"
   },
   "engines": {
-    "node": ">= 12.13.0",
-    "yarn": ">= 1.19.1"
+    "node": "= 12.13",
+    "yarn": "= 1.19"
   },
   "resolutions": {
     "**/request": "https://github.com/request/request/archive/392db7d127536ff296fb06492db9430790a32d6c.tar.gz"


### PR DESCRIPTION
We weren't able to deploy this successfully on Node 20.x and Yarn 3.6.x. Locking to the version to known-working but ancient versions allowed things to build successfully.